### PR TITLE
 添加attr_accessible :tags_attributes，解决添加Tag后，新建Post报错的问题

### DIFF
--- a/source/CN/getting_started.textile
+++ b/source/CN/getting_started.textile
@@ -1296,6 +1296,7 @@ class Post < ActiveRecord::Base
                     :length => { :minimum => 5 }
 
   has_many :comments, :dependent => :destroy
+  attr_accessible :tags_attributes
   has_many :tags
   accepts_nested_attributes_for :tags, :allow_destroy => :true,
   :reject_if => proc { |attrs| attrs.all? { |k, v| v.blank? } }


### PR DESCRIPTION
添加attr_accessible :tags_attributes，解决添加Tag后，新建Post，提交时报错：
Can't mass-assign protected attributes: tags_attributes
