### PR TITLE
修复md->html后缀问题

### DIFF
--- a/rails_guides/generator.rb
+++ b/rails_guides/generator.rb
@@ -123,7 +123,7 @@ module RailsGuides
       if guide =~/\.textile$/
         guide.sub(/\.textile$/, '.html')
       elsif guide=~/\.(markdown|md)$/
-        guide.sub(/\.markdown|md$/,'.html')
+        guide.sub(/\.(markdown|md)$/,'.html')
       else
         guide.sub(/\.erb$/, '')
       end


### PR DESCRIPTION
`rake generate_guides_CN` 后`*.md`文件生成为`*..html`，如 association_basics.md->association_basics..html。
